### PR TITLE
Improve wording of `kube-node-lease` namespace doc

### DIFF
--- a/content/en/docs/concepts/overview/working-with-objects/namespaces.md
+++ b/content/en/docs/concepts/overview/working-with-objects/namespaces.md
@@ -62,7 +62,7 @@ Kubernetes starts with four initial namespaces:
    * `default` The default namespace for objects with no other namespace
    * `kube-system` The namespace for objects created by the Kubernetes system
    * `kube-public` This namespace is created automatically and is readable by all users (including those not authenticated). This namespace is mostly reserved for cluster usage, in case that some resources should be visible and readable publicly throughout the whole cluster. The public aspect of this namespace is only a convention, not a requirement.
-   * `kube-node-lease` This namespace for the lease objects associated with each node which improves the performance of the node heartbeats as the cluster scales.
+   * `kube-node-lease` The namespace for lease objects associated with each node, which improves the performance of [heartbeats](/docs/concepts/architecture/nodes/#heartbeats) as the cluster scales.
    
 ### Setting the namespace for a request
 


### PR DESCRIPTION
Correct grammar and provide a reference to more detailed documentation of concepts mentioned.